### PR TITLE
Issue #30: handle historical API rate limits gracefully

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,7 +88,6 @@ def fetch_forecast_and_current(vc_api_key: str) -> tuple[pd.DataFrame, dict]:
     live_feelslike = current.get("feelslike")
     live_windspeed = current.get("windspeed")
     live_winddeg = current.get("wdir")
-
     if live_actual is None and not forecast_df.empty:
         live_actual = forecast_df.iloc[-1]["Actual"]
     if live_feelslike is None and not forecast_df.empty:
@@ -154,6 +153,10 @@ def fetch_historical_band(today_str: str, vc_api_key: str) -> pd.DataFrame:
                             "WindSpeed": windspeed,
                         })
         except requests.RequestException as e:
+            status_code = getattr(getattr(e, "response", None), "status_code", None)
+            if status_code == 429:
+                logger.warning("Historical fetch rate-limited on %s; stopping further yearly requests.", date_str)
+                break
             logger.warning("Historical fetch failed for %s: %s", date_str, e)
             continue
 
@@ -472,6 +475,10 @@ def run_app() -> None:
             hist_band = fetch_historical_band(today_str, vc_api_key)
             if not hist_band.empty:
                 st.session_state["hist_band"] = hist_band
+            else:
+                hist_band = st.session_state.get("hist_band", pd.DataFrame(columns=["Hour", "HistHigh", "HistLow", "HistMean"]))
+                if hist_band.empty:
+                    st.caption("⚠️ Historical band temporarily unavailable.")
         except requests.RequestException as e:
             logger.warning("Historical band fetch failed, using cached fallback: %s", e)
             hist_band = st.session_state.get("hist_band", pd.DataFrame(columns=["Hour", "HistHigh", "HistLow", "HistMean"]))

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -146,6 +146,25 @@ def test_fetch_historical_band_partial_failure_still_aggregates(monkeypatch):
     assert row_h0["WindSpeedMean"] == 5.0
 
 
+def test_fetch_historical_band_stops_after_first_429(monkeypatch):
+    call_count = 0
+
+    def fake_get(url, params, timeout):
+        nonlocal call_count
+        call_count += 1
+        error = app.requests.HTTPError("429 Client Error")
+        error.response = type("Response", (), {"status_code": 429})()
+        raise error
+
+    monkeypatch.setattr(app, "HISTORY_YEARS", 5)
+    monkeypatch.setattr(app.requests, "get", fake_get)
+
+    band = app.fetch_historical_band.__wrapped__("2025-03-16", "fake-key")
+
+    assert band.empty
+    assert call_count == 1
+
+
 def test_build_chart_layers_without_hist_band():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
Summary:
This PR makes historical weather fetching resilient to Visual Crossing rate limits.

What changed:
- Stop issuing additional yearly historical requests after the first HTTP 429.
- Fall back cleanly when fresh historical data is unavailable.
- Preserve app usability when historical band data cannot be fetched.
- Add a unit test covering the 429 short-circuit behavior.

Validation:
- Full pytest suite passes locally.

Closes #30