### PR TITLE
feat: add ruff linting config and CI enforcement (closes #10)

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Check formatting
         run: python -m ruff format --check .
+
+      - name: Check linting
+        run: python -m ruff check .

--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ python -m ruff format --check .
 Formatting checks run automatically on push and pull request workflows.
 If formatting is not compliant, CI fails and the PR cannot be merged until formatting is fixed.
 
+## Linting (Ruff)
+
+This repository uses Ruff for linting (pycodestyle errors, Pyflakes, and warnings).
+
+### Local commands
+
+Run the linter:
+
+python -m ruff check .
+
+Auto-fix safe issues:
+
+python -m ruff check --fix .
+
+### CI behavior
+
+Lint checks run automatically on push and pull request workflows alongside formatting checks.
+If any lint errors are reported, CI fails and the PR cannot be merged until they are resolved.
+
 ## Test Command
 
 Run the test suite locally:

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import streamlit as st
 import requests
 import pandas as pd
 import altair as alt
-from datetime import datetime, timedelta
+from datetime import datetime
 import pytz
 import logging
 import math

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,7 @@ target-version = "py311"
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]
+ignore = ["E501"]


### PR DESCRIPTION
Closes #10

## Changes

- **`pyproject.toml`**: added `[tool.ruff.lint]` with `select = ["E", "F", "W"]` and `ignore = ["E501"]`
- **`.github/workflows/format.yml`**: added `ruff check .` step after the existing format check
- **`README.md`**: added Linting section with local commands and CI behavior
- **`app.py`**: removed unused `timedelta` import caught by new F401 rule