### PR TITLE
feat(issue-52): add dev guardrail operator controls and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,59 @@ If any lint errors are reported, CI fails and the PR cannot be merged until they
 Run the test suite locally:
 
 python -m pytest -q
+
+## Dev API Guardrails
+
+Issue #50 introduced development-time API guardrails to reduce accidental quota burn while still allowing live verification when explicitly enabled.
+
+### Runtime Profiles
+
+- `prod`: Always live API mode.
+- `dev-safe`: Forces sample mode unless live access is explicitly allowed.
+- `dev-live`: Dev mode with live API enabled by explicit opt-in.
+
+### Required Dev Flags
+
+- `ENV=dev`
+- `DEV_ALLOW_LIVE_API=true` to permit live calls in dev.
+- `DEV_USE_SAMPLE_DATA=true|false` to choose sample/live within dev-live.
+
+### Guardrail Budget Variables
+
+- `DEV_BUDGET_VC_FORECAST` (default: `12`)
+- `DEV_BUDGET_VC_HISTORICAL` (default: `3`)
+- `DEV_BUDGET_OPEN_METEO_WIND` (default: `24`)
+- `DEV_API_COOLDOWN_MINUTES` (default: `30`)
+
+Invalid values fall back to defaults. Negative budget values clamp to `0`.
+
+### Persisted State
+
+Guardrail state is stored at:
+
+`.streamlit/guardrails/dev_api_state.json`
+
+State keys:
+
+- `date`
+- `usage`
+- `blocked`
+- `cooldowns`
+
+State is effectively day-scoped: when the saved `date` does not match today, the app starts from a fresh state for the new day.
+
+### Operator Controls (Dev UI)
+
+In the sidebar under **Dev API Guardrails**:
+
+- `Reset usage + blocked`: clears daily usage and blocked counters.
+- `Clear cooldowns`: removes active cooldown entries.
+- `Show raw guardrail state`: displays persisted JSON state for debugging.
+
+### Fallback Message Semantics
+
+Guardrail-aware fallback copy distinguishes:
+
+- Budget exhausted for a provider
+- Cooldown active after a 429
+- General transient API/request failure

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import requests
 import pandas as pd
 import altair as alt
 from datetime import datetime, timedelta
+from contextlib import nullcontext
 import pytz
 import logging
 import math
@@ -298,6 +299,38 @@ def _save_dev_guardrail_state(state: Mapping[str, Any]) -> None:
     path = _dev_guardrail_state_path()
     with open(path, "w", encoding="utf-8") as f:
         json.dump(state, f, indent=2, sort_keys=True)
+
+
+def reset_dev_guardrail_usage_and_blocked(
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Reset usage and blocked counters for today's guardrail state."""
+    current = _guardrail_now(now)
+    date_str = current.strftime("%Y-%m-%d")
+    state = _load_dev_guardrail_state(date_str)
+    state["usage"] = {}
+    state["blocked"] = {}
+    _save_dev_guardrail_state(state)
+    return state
+
+
+def clear_dev_guardrail_cooldowns(
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Clear cooldown entries for today's guardrail state."""
+    current = _guardrail_now(now)
+    date_str = current.strftime("%Y-%m-%d")
+    state = _load_dev_guardrail_state(date_str)
+    state["cooldowns"] = {}
+    _save_dev_guardrail_state(state)
+    return state
+
+
+def get_dev_guardrail_raw_state(now: datetime | None = None) -> dict[str, Any]:
+    """Return today's persisted guardrail state for debugging."""
+    current = _guardrail_now(now)
+    date_str = current.strftime("%Y-%m-%d")
+    return _load_dev_guardrail_state(date_str)
 
 
 def _get_dev_budget_limits(
@@ -1382,6 +1415,35 @@ def run_app() -> None:
                     st.sidebar.caption(line)
                 else:
                     st.caption(line)
+
+        controls_ctx = (
+            st.sidebar.expander("Guardrail Controls", expanded=False)
+            if hasattr(st.sidebar, "expander")
+            else nullcontext()
+        )
+        with controls_ctx:
+            sidebar_button = st.sidebar.button if hasattr(st.sidebar, "button") else st.button
+            sidebar_checkbox = (
+                st.sidebar.checkbox if hasattr(st.sidebar, "checkbox") else st.checkbox
+            )
+
+            if sidebar_button("Reset usage + blocked", key="guardrail_reset_usage"):
+                reset_dev_guardrail_usage_and_blocked(now=now_mtn)
+                st.success("Dev guardrail usage and blocked counters reset.")
+                st.rerun()
+
+            if sidebar_button("Clear cooldowns", key="guardrail_clear_cooldowns"):
+                clear_dev_guardrail_cooldowns(now=now_mtn)
+                st.success("Dev guardrail cooldowns cleared.")
+                st.rerun()
+
+            if sidebar_checkbox("Show raw guardrail state", value=False, key="guardrail_show_raw"):
+                raw_state = get_dev_guardrail_raw_state(now=now_mtn)
+                raw_json = json.dumps(raw_state, indent=2, sort_keys=True)
+                if hasattr(st.sidebar, "code"):
+                    st.sidebar.code(raw_json, language="json")
+                else:
+                    st.code(raw_json, language="json")
 
     if _is_dev and not runtime["live_api_enabled"] and not runtime["dev_use_sample_requested"]:
         st.warning(

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -271,6 +271,88 @@ def test_format_dev_guardrail_fallback_distinguishes_budget_and_cooldown():
     assert "cached or forecast wind data" in cooldown_msg
 
 
+def test_get_dev_budget_limits_invalid_values_fall_back_to_defaults():
+    limits = app._get_dev_budget_limits(
+        secrets={},
+        environ={
+            "DEV_BUDGET_VC_FORECAST": "abc",
+            "DEV_BUDGET_VC_HISTORICAL": "",
+            "DEV_BUDGET_OPEN_METEO_WIND": "-5",
+        },
+    )
+
+    assert (
+        limits["visual_crossing_forecast"]
+        == app.DEV_API_BUDGET_DEFAULTS["visual_crossing_forecast"]
+    )
+    assert (
+        limits["visual_crossing_historical"]
+        == app.DEV_API_BUDGET_DEFAULTS["visual_crossing_historical"]
+    )
+    assert limits["open_meteo_wind"] == 0
+
+
+def test_reset_dev_guardrail_usage_and_blocked_clears_counters_only(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    now = app.LOCAL_TZ.localize(datetime(2026, 3, 20, 8, 0, 0))
+    date_str = now.strftime("%Y-%m-%d")
+    app._save_dev_guardrail_state(
+        {
+            "date": date_str,
+            "usage": {"visual_crossing_forecast": 3},
+            "blocked": {"visual_crossing_forecast": 2},
+            "cooldowns": {"visual_crossing_forecast": now.isoformat()},
+        }
+    )
+
+    state = app.reset_dev_guardrail_usage_and_blocked(now=now)
+
+    assert state["usage"] == {}
+    assert state["blocked"] == {}
+    assert "visual_crossing_forecast" in state["cooldowns"]
+
+
+def test_clear_dev_guardrail_cooldowns_keeps_usage_and_blocked(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    now = app.LOCAL_TZ.localize(datetime(2026, 3, 20, 9, 0, 0))
+    date_str = now.strftime("%Y-%m-%d")
+    app._save_dev_guardrail_state(
+        {
+            "date": date_str,
+            "usage": {"open_meteo_wind": 4},
+            "blocked": {"open_meteo_wind": 1},
+            "cooldowns": {"open_meteo_wind": now.isoformat()},
+        }
+    )
+
+    state = app.clear_dev_guardrail_cooldowns(now=now)
+
+    assert state["cooldowns"] == {}
+    assert state["usage"] == {"open_meteo_wind": 4}
+    assert state["blocked"] == {"open_meteo_wind": 1}
+
+
+def test_get_dev_guardrail_raw_state_rolls_over_to_today(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    yesterday = app.LOCAL_TZ.localize(datetime(2026, 3, 19, 23, 0, 0))
+    app._save_dev_guardrail_state(
+        {
+            "date": yesterday.strftime("%Y-%m-%d"),
+            "usage": {"visual_crossing_forecast": 99},
+            "blocked": {"visual_crossing_forecast": 10},
+            "cooldowns": {"visual_crossing_forecast": yesterday.isoformat()},
+        }
+    )
+
+    today = app.LOCAL_TZ.localize(datetime(2026, 3, 20, 7, 0, 0))
+    state = app.get_dev_guardrail_raw_state(now=today)
+
+    assert state["date"] == "2026-03-20"
+    assert state["usage"] == {}
+    assert state["blocked"] == {}
+    assert state["cooldowns"] == {}
+
+
 def test_fetch_forecast_and_current_keeps_hours_when_wdir_missing(monkeypatch):
     payload = {
         "days": [


### PR DESCRIPTION
Add dev UI controls to reset usage/blocked counters, clear cooldowns, and inspect raw guardrail state; document guardrail configuration and behavior; and extend tests for rollover, invalid config, and reset helpers.

Refs #50
Closes https://github.com/RobinWikoff/the-farm-monitor/issues/52