### PR TITLE
feat(issue-45): enforce ci runtime and test guardrails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,10 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || inputs.run_live_api_tests == false
     runs-on: ubuntu-latest
     env:
+      CI: "true"
+      ENV: "dev"
+      DEV_ALLOW_LIVE_API: "false"
+      DEV_USE_SAMPLE_DATA: "true"
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
@@ -41,6 +45,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Log effective runtime profile
+        run: |
+          python - <<'PY'
+          import app
+          cfg = app.resolve_runtime_config({}, None)
+          print(f"profile={cfg['profile']}")
+          print(f"live_api_enabled={cfg['live_api_enabled']}")
+          print(f"effective_data_mode={cfg['effective_data_mode']}")
+          print(f"policy_reason={cfg['policy_reason']}")
+          PY
+
       - name: Run tests excluding live API marker
         run: pytest -q -m "not live_api"
 
@@ -49,6 +64,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.run_live_api_tests == true
     runs-on: ubuntu-latest
     env:
+      CI: "true"
+      ENV: "dev"
+      DEV_ALLOW_LIVE_API: "true"
+      DEV_USE_SAMPLE_DATA: "false"
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       RUN_LIVE_INTEGRATION_TESTS: "true"
       VISUAL_CROSSING_API_KEY: ${{ secrets.VISUAL_CROSSING_API_KEY }}
@@ -74,6 +93,17 @@ jobs:
             echo "Add repository secret VISUAL_CROSSING_API_KEY before running this job."
             exit 1
           fi
+
+      - name: Log effective runtime profile
+        run: |
+          python - <<'PY'
+          import app
+          cfg = app.resolve_runtime_config({}, None)
+          print(f"profile={cfg['profile']}")
+          print(f"live_api_enabled={cfg['live_api_enabled']}")
+          print(f"effective_data_mode={cfg['effective_data_mode']}")
+          print(f"policy_reason={cfg['policy_reason']}")
+          PY
 
       - name: Run live API tests only
         run: pytest -q -m live_api

--- a/app.py
+++ b/app.py
@@ -223,6 +223,10 @@ def resolve_runtime_config(
     env_raw = _get_cfg_value("ENV", secrets, environ)
     env_name = str(env_raw if env_raw is not None else "prod").strip().lower()
     is_dev = env_name == "dev"
+    is_ci = _as_bool(_get_cfg_value("CI", secrets, environ), default=False) or _as_bool(
+        _get_cfg_value("GITHUB_ACTIONS", secrets, environ), default=False
+    )
+    run_live_tests = _as_bool(_get_cfg_value("RUN_LIVE_INTEGRATION_TESTS", secrets, environ))
 
     requested_sample_raw = _get_cfg_value("DEV_USE_SAMPLE_DATA", secrets, environ)
     requested_sample_default = True if is_dev else False
@@ -231,7 +235,17 @@ def resolve_runtime_config(
     allow_live_raw = _get_cfg_value("DEV_ALLOW_LIVE_API", secrets, environ)
     dev_allow_live_api = _as_bool(allow_live_raw, default=False)
 
-    if is_dev and not dev_allow_live_api:
+    if is_ci and run_live_tests:
+        effective_data_mode = "live"
+        live_api_enabled = True
+        policy_reason = "CI live mode enabled by explicit RUN_LIVE_INTEGRATION_TESTS opt-in."
+        profile = "ci-live-manual"
+    elif is_ci:
+        effective_data_mode = "sample"
+        live_api_enabled = False
+        policy_reason = "CI non-live mode disables live APIs by default."
+        profile = "ci-non-live"
+    elif is_dev and not dev_allow_live_api:
         effective_data_mode = "sample"
         live_api_enabled = False
         policy_reason = "DEV_ALLOW_LIVE_API is false; forcing sample mode in dev."
@@ -254,6 +268,7 @@ def resolve_runtime_config(
     return {
         "env": env_name,
         "is_dev": is_dev,
+        "is_ci": is_ci,
         "profile": profile,
         "dev_allow_live_api": dev_allow_live_api,
         "dev_use_sample_requested": dev_use_sample_requested,
@@ -261,6 +276,42 @@ def resolve_runtime_config(
         "live_api_enabled": live_api_enabled,
         "policy_reason": policy_reason,
     }
+
+
+def validate_runtime_config(runtime: Mapping[str, Any]) -> list[str]:
+    issues: list[str] = []
+    profile = runtime.get("profile")
+    effective_data_mode = runtime.get("effective_data_mode")
+    live_api_enabled = runtime.get("live_api_enabled")
+
+    expected_profiles = {
+        "dev-safe",
+        "dev-live",
+        "ci-non-live",
+        "ci-live-manual",
+        "prod",
+    }
+    if profile not in expected_profiles:
+        issues.append(f"Unknown runtime profile: {profile}")
+
+    if profile == "ci-non-live":
+        if live_api_enabled:
+            issues.append("ci-non-live must not enable live APIs.")
+        if effective_data_mode != "sample":
+            issues.append("ci-non-live must use sample mode.")
+    elif profile == "ci-live-manual":
+        if not live_api_enabled:
+            issues.append("ci-live-manual must enable live APIs.")
+        if effective_data_mode != "live":
+            issues.append("ci-live-manual must use live mode.")
+    elif profile == "dev-safe":
+        if live_api_enabled or effective_data_mode != "sample":
+            issues.append("dev-safe must disable live APIs and use sample mode.")
+    elif profile == "prod":
+        if not live_api_enabled or effective_data_mode != "live":
+            issues.append("prod must enable live APIs and use live mode.")
+
+    return issues
 
 
 def _dev_guardrail_state_path() -> str:
@@ -1356,6 +1407,7 @@ def build_precip_chart(df: pd.DataFrame, current_hour: int) -> alt.LayerChart:
 def run_app() -> None:
     secrets = _get_streamlit_secrets()
     runtime = resolve_runtime_config(secrets, os.environ)
+    runtime_issues = validate_runtime_config(runtime)
     _is_dev = runtime["is_dev"]
     _page_title = "The Farm [DEV]" if _is_dev else "The Farm"
 
@@ -1383,6 +1435,10 @@ def run_app() -> None:
         st.sidebar.caption(runtime_line)
     else:
         st.caption(runtime_line)
+
+    if runtime_issues:
+        st.error("Invalid runtime configuration: " + " | ".join(runtime_issues))
+        st.stop()
 
     if _is_dev:
         snapshot = get_dev_guardrail_snapshot(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import os
+
+import pytest
+import requests
+
+
+def _as_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@pytest.fixture(autouse=True)
+def block_external_http_in_non_live_tests(monkeypatch, request):
+    is_live_test = request.node.get_closest_marker("live_api") is not None
+    live_enabled = _as_bool(os.getenv("RUN_LIVE_INTEGRATION_TESTS"))
+    if is_live_test and live_enabled:
+        return
+
+    def guarded_request(self, method, url, *args, **kwargs):
+        raise AssertionError(f"External HTTP blocked in non-live tests: {method.upper()} {url}")
+
+    monkeypatch.setattr(requests.sessions.Session, "request", guarded_request)

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -90,6 +91,51 @@ def test_resolve_runtime_config_prod_uses_live_mode():
     assert cfg["profile"] == "prod"
     assert cfg["effective_data_mode"] == "live"
     assert cfg["live_api_enabled"] is True
+
+
+def test_resolve_runtime_config_ci_non_live_forces_sample_mode():
+    cfg = app.resolve_runtime_config(
+        secrets={},
+        environ={"CI": "true", "ENV": "prod", "DEV_ALLOW_LIVE_API": "true"},
+    )
+
+    assert cfg["profile"] == "ci-non-live"
+    assert cfg["effective_data_mode"] == "sample"
+    assert cfg["live_api_enabled"] is False
+
+
+def test_resolve_runtime_config_ci_live_manual_requires_explicit_flag():
+    cfg = app.resolve_runtime_config(
+        secrets={},
+        environ={
+            "CI": "true",
+            "RUN_LIVE_INTEGRATION_TESTS": "true",
+            "ENV": "dev",
+            "DEV_USE_SAMPLE_DATA": "true",
+        },
+    )
+
+    assert cfg["profile"] == "ci-live-manual"
+    assert cfg["effective_data_mode"] == "live"
+    assert cfg["live_api_enabled"] is True
+
+
+def test_validate_runtime_config_flags_invalid_ci_non_live_combinations():
+    issues = app.validate_runtime_config(
+        {
+            "profile": "ci-non-live",
+            "effective_data_mode": "live",
+            "live_api_enabled": True,
+        }
+    )
+
+    assert "ci-non-live must not enable live APIs." in issues
+    assert "ci-non-live must use sample mode." in issues
+
+
+def test_non_live_network_guard_blocks_requests():
+    with pytest.raises(AssertionError, match="External HTTP blocked in non-live tests"):
+        requests.get("https://example.com", timeout=1)
 
 
 def test_check_and_record_dev_api_request_increments_usage_and_blocks_at_cap(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #45

## Summary
This PR adds the first enforcement slice for dev/live mode guardrails in CI and runtime.

## What changed
1. Added CI-specific runtime profiles:
   - `ci-non-live`
   - `ci-live-manual`

2. Added runtime validation:
   - validates profile/data-mode/live-API consistency
   - stops app startup if runtime config is internally invalid

3. Added non-live test network protection:
   - blocks outbound HTTP in non-live pytest runs
   - allows HTTP only for explicitly enabled `live_api` tests

4. Tightened CI workflow behavior:
   - non-live job now explicitly runs in safe dev/sample mode
   - live job now explicitly runs in opt-in live mode
   - both jobs log effective runtime profile and policy

5. Extended guardrail regression coverage:
   - CI non-live profile semantics
   - CI live-manual profile semantics
   - runtime drift detection
   - non-live network blocking

## Why
Issue #44 established the runtime-mode architecture.
Issue #50 and #52 added budgets, cooldowns, diagnostics, and operator controls.
This PR makes those guardrails enforceable in CI and test execution so drift cannot silently re-enable live API calls in non-live paths.

## Validation
- `ruff check app.py tests/test_core_logic.py tests/conftest.py`
- `ruff format --check app.py tests/test_core_logic.py tests/conftest.py`
- `pytest -q -m "not live_api"`

## Notes
This is the first enforcement slice for #45.
A follow-up slice can add stricter ambiguous-config rejection and a dedicated config-sanity regression suite.