### PR TITLE
feat: kitty wind cutoff slider in sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -1378,25 +1378,28 @@ def render_status_banner(
                 )
 
 
-def render_wind_banner(
-    fastest_wind_speed: float | None,
-    fastest_wind_hour: int | None,
-) -> None:
-    """Show summary banner for today's fastest forecasted wind."""
-    if fastest_wind_speed is None or fastest_wind_hour is None:
-        st.warning("💨 Wind information is currently unavailable.")
-        return
-    st.info(
-        f"💨 Today's Fastest Wind Forecasted: {fastest_wind_speed} mph at {fastest_wind_hour:02d}:00."
-    )
-
-
 # ---------------------------------------------------------------------------
 # KITTY COMFORT
 # ---------------------------------------------------------------------------
 KITTY_TEMP_MIN_F: float = 32.0
 KITTY_TEMP_MAX_F: float = 85.0
-KITTY_WIND_THRESHOLD_MPH: float = 5.0
+KITTY_WIND_THRESHOLD_MPH: float = 20.0
+
+
+def render_wind_banner(
+    fastest_wind_speed: float | None,
+    fastest_wind_hour: int | None,
+    wind_threshold: float = KITTY_WIND_THRESHOLD_MPH,
+) -> None:
+    """Show summary banner for today's fastest forecasted wind."""
+    if fastest_wind_speed is None or fastest_wind_hour is None:
+        st.warning("💨 Wind information is currently unavailable.")
+        return
+    base = f"💨 Today's Fastest Wind Forecasted: {fastest_wind_speed} mph at {fastest_wind_hour:02d}:00."
+    if fastest_wind_speed > wind_threshold:
+        st.warning(base + f" ⚠️ Exceeds kitty wind cutoff ({wind_threshold:.0f} mph).")
+    else:
+        st.info(base)
 
 
 def kitty_comfort_status(
@@ -1404,6 +1407,7 @@ def kitty_comfort_status(
     wind_speed: float | None,
     wind_gust: float | None,
     rain_or_snow: bool,
+    wind_threshold: float = KITTY_WIND_THRESHOLD_MPH,
 ) -> dict[str, str]:
     """Return a dict with 'temp', 'wind', and optionally 'precip' status strings.
 
@@ -1436,15 +1440,15 @@ def kitty_comfort_status(
         effective_wind = max(candidates)
 
     if effective_wind is not None:
-        if effective_wind > KITTY_WIND_THRESHOLD_MPH:
+        if effective_wind > wind_threshold:
             result["wind"] = (
                 f"Too windy for Kitties: {effective_wind:.0f} mph "
-                f"-- (More than {KITTY_WIND_THRESHOLD_MPH:.0f} mph)"
+                f"-- (More than {wind_threshold:.0f} mph)"
             )
         else:
             result["wind"] = (
                 f"Not too windy for Kitties: {effective_wind:.0f} mph "
-                f"-- ({KITTY_WIND_THRESHOLD_MPH:.0f} mph or less)"
+                f"-- ({wind_threshold:.0f} mph or less)"
             )
 
     # Precipitation status — only shown when actively raining/snowing
@@ -1459,9 +1463,10 @@ def render_kitty_comfort_banner(
     wind_speed: float | None,
     wind_gust: float | None,
     rain_or_snow: bool,
+    wind_threshold: float = KITTY_WIND_THRESHOLD_MPH,
 ) -> None:
     """Render the Kitty Comfort Threshold section above the temperature area."""
-    status = kitty_comfort_status(live_temp_f, wind_speed, wind_gust, rain_or_snow)
+    status = kitty_comfort_status(live_temp_f, wind_speed, wind_gust, rain_or_snow, wind_threshold)
 
     temp_ok = KITTY_TEMP_MIN_F < live_temp_f <= KITTY_TEMP_MAX_F
     wind_ok = "wind" not in status or status["wind"].startswith("Not too windy")
@@ -1909,6 +1914,14 @@ def run_app() -> None:
     selected_temp_key = "FeelsLike" if temp_mode == "Feels Like" else "Actual"
     selected_metric_title = f"{temp_mode} Now"
 
+    kitty_wind_cutoff = st.sidebar.slider(
+        "Kitty Wind Cutoff (mph)",
+        min_value=0,
+        max_value=40,
+        value=int(KITTY_WIND_THRESHOLD_MPH),
+        step=5,
+    )
+
     runtime_line = (
         f"Profile: {runtime['profile']} | Data mode: {runtime['effective_data_mode']} | "
         f"Live API: {'on' if runtime['live_api_enabled'] else 'off'}"
@@ -2120,6 +2133,7 @@ def run_app() -> None:
         wind_speed=live_temp.get("WindSpeed"),
         wind_gust=live_temp.get("WindGust"),
         rain_or_snow=_kc_rain_or_snow,
+        wind_threshold=kitty_wind_cutoff,
     )
 
     # Metrics
@@ -2201,7 +2215,7 @@ def run_app() -> None:
     else:
         strongest_gust = float(wind_actuals["WindGust"].max())
 
-    render_wind_banner(fastest_wind_speed, fastest_wind_hour)
+    render_wind_banner(fastest_wind_speed, fastest_wind_hour, wind_threshold=kitty_wind_cutoff)
 
     if current_hour == 0:
         wind_delta_str = None

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -1119,6 +1119,7 @@ def test_kitty_comfort_good_temp_no_wind_no_precip():
         wind_speed=2.0,
         wind_gust=3.0,
         rain_or_snow=False,
+        wind_threshold=5.0,
     )
     assert "Good Temperature" in status["temp"]
     assert ": 65.0°F --" in status["temp"]
@@ -1197,6 +1198,7 @@ def test_kitty_comfort_too_windy_by_speed():
         wind_speed=6.0,
         wind_gust=4.0,
         rain_or_snow=False,
+        wind_threshold=5.0,
     )
     assert "Too windy" in status["wind"]
     assert ": 6 mph --" in status["wind"]
@@ -1210,6 +1212,7 @@ def test_kitty_comfort_too_windy_by_gust():
         wind_speed=3.0,
         wind_gust=8.0,
         rain_or_snow=False,
+        wind_threshold=5.0,
     )
     assert "Too windy" in status["wind"]
 
@@ -1221,6 +1224,7 @@ def test_kitty_comfort_exactly_5mph_is_not_too_windy():
         wind_speed=5.0,
         wind_gust=5.0,
         rain_or_snow=False,
+        wind_threshold=5.0,
     )
     assert "Not too windy" in status["wind"]
 
@@ -1235,12 +1239,26 @@ def test_kitty_comfort_wind_unavailable_omits_wind_key():
     assert "wind" not in status
 
 
+def test_kitty_comfort_custom_wind_threshold_respected():
+    """Wind that would be fine at default 20 mph is flagged at a custom 10 mph cutoff."""
+    status = app.kitty_comfort_status(
+        live_temp_f=65.0,
+        wind_speed=15.0,
+        wind_gust=None,
+        rain_or_snow=False,
+        wind_threshold=10.0,
+    )
+    assert "Too windy" in status["wind"]
+    assert "(More than 10 mph)" in status["wind"]
+
+
 def test_kitty_comfort_wind_speed_only_no_gust():
     status = app.kitty_comfort_status(
         live_temp_f=65.0,
         wind_speed=7.0,
         wind_gust=None,
         rain_or_snow=False,
+        wind_threshold=5.0,
     )
     assert "Too windy" in status["wind"]
 
@@ -1272,6 +1290,7 @@ def test_kitty_comfort_all_bad_conditions():
         wind_speed=15.0,
         wind_gust=20.0,
         rain_or_snow=True,
+        wind_threshold=5.0,
     )
     assert "too cold" in status["temp"].lower()
     assert "Too windy" in status["wind"]
@@ -1310,6 +1329,7 @@ def test_render_kitty_comfort_banner_bad_conditions_uses_error(monkeypatch):
         wind_speed=10.0,
         wind_gust=12.0,
         rain_or_snow=True,
+        wind_threshold=5.0,
     )
 
     assert captured["type"] == "error"

--- a/tests/test_integration_live_api.py
+++ b/tests/test_integration_live_api.py
@@ -128,6 +128,15 @@ class _DummySidebar:
     def radio(self, *args, **kwargs):
         return "Feels Like"
 
+    def slider(self, label, min_value=0, max_value=100, value=0, step=1, **kwargs):
+        return value
+
+    def caption(self, *args, **kwargs):
+        return None
+
+    def markdown(self, *args, **kwargs):
+        return None
+
     def expander(self, *args, **kwargs):
         return _DummyContext()
 


### PR DESCRIPTION
Closes #67

## Changes
- Sidebar slider **\"Kitty Wind Cutoff (mph)\"** — range 0–40 mph, default 20, step 5
- `kitty_comfort_status()` — new `wind_threshold` parameter (default `KITTY_WIND_THRESHOLD_MPH = 20.0`)
- `render_kitty_comfort_banner()` — accepts and passes through `wind_threshold`
- `render_wind_banner()` — shows `st.warning` (instead of `st.info`) with an ⚠️ note when today's fastest forecast wind exceeds the cutoff
- `KITTY_WIND_THRESHOLD_MPH` changed from 5.0 → 20.0 (matches new slider default)
- Constants block moved above `render_wind_banner` so default argument resolves at definition time

## Tests
- Existing wind-boundary tests updated with explicit `wind_threshold=5.0` to preserve their intent
- New test: `test_kitty_comfort_custom_wind_threshold_respected`
- 95/95 passing, ruff clean"