### PR TITLE
feat(rust): phase C part 2 dashboard data wiring

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -156,7 +156,10 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "farm-monitor-api"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
+ "chrono",
+ "farm-monitor-data",
  "farm-monitor-domain",
  "tokio",
  "tracing",

--- a/rust/crates/farm-monitor-api/Cargo.toml
+++ b/rust/crates/farm-monitor-api/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = { workspace = true }
 axum = { workspace = true }
+chrono = { workspace = true }
+farm-monitor-data = { path = "../farm-monitor-data" }
 farm-monitor-domain = { path = "../farm-monitor-domain" }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rust/crates/farm-monitor-api/src/main.rs
+++ b/rust/crates/farm-monitor-api/src/main.rs
@@ -3,8 +3,15 @@ use axum::{
     routing::get,
     Json, Router,
 };
+use chrono::{Timelike, Utc};
+use farm_monitor_data::models::ProviderPoint;
+use farm_monitor_data::{
+    normalize_provider_response, FileForecastCache, ForecastBundle, ForecastPoint, LocationRequest,
+    ProviderForecastResponse,
+};
 use farm_monitor_domain::HealthStatus;
 use std::net::SocketAddr;
+use std::{f64::consts::PI, fmt::Write};
 use tracing::info;
 
 #[tokio::main]
@@ -38,11 +45,111 @@ async fn index() -> Redirect {
 }
 
 async fn dashboard() -> Html<String> {
-    Html(dashboard_html())
+    match load_dashboard_bundle() {
+        Ok(bundle) => Html(dashboard_html(&bundle)),
+        Err(err) => Html(error_dashboard_html(&format!(
+            "failed to load dashboard data: {err}"
+        ))),
+    }
 }
 
-fn dashboard_html() -> String {
-    let html = r#"<!doctype html>
+fn load_dashboard_bundle() -> anyhow::Result<ForecastBundle> {
+    let now = Utc::now();
+    let today = now.date_naive();
+    let cache = FileForecastCache::new(".streamlit/rust_cache");
+
+    if let Some(bundle) = cache.read(today)? {
+        return Ok(bundle);
+    }
+
+    let location = LocationRequest {
+        lat: 40.39,
+        lon: -105.07,
+    };
+    let provider = mock_provider_forecast(&location);
+    let normalized = normalize_provider_response(provider);
+
+    cache.write(today, &normalized)?;
+    let _ = cache.cleanup_older_than(14, now);
+
+    Ok(normalized)
+}
+
+fn mock_provider_forecast(_location: &LocationRequest) -> ProviderForecastResponse {
+    let generated_at = Utc::now();
+    let mut hourly = Vec::with_capacity(24);
+
+    for hour in 0..24u8 {
+        let h = hour as f64;
+        let temp = 54.0 + 12.0 * ((h - 6.0) * PI / 12.0).sin();
+        let feels = temp - 1.3 + 1.2 * (h * PI / 6.0).sin();
+        let wind = (8.0 + 3.8 * ((h + 2.0) * PI / 12.0).sin()).max(0.0);
+        let aqi = (64.0 + 34.0 * ((h - 4.0) * PI / 10.0).sin()).clamp(15.0, 220.0);
+        let uv = if (6.0..=18.0).contains(&h) {
+            (8.5 * ((h - 6.0) * PI / 12.0).sin()).max(0.0)
+        } else {
+            0.0
+        };
+        let cloud = (43.0 + 33.0 * ((h - 10.0) * PI / 14.0).sin()).clamp(0.0, 100.0);
+
+        hourly.push(ProviderPoint {
+            hour,
+            temp_f: Some(temp),
+            feels_like_f: Some(feels),
+            wind_mph: Some(wind),
+            aqi: Some(aqi),
+            uv_index: Some(uv),
+            cloud_cover_pct: Some(cloud),
+        });
+    }
+
+    ProviderForecastResponse {
+        source: "mock-phase-c".to_string(),
+        generated_at,
+        hourly,
+    }
+}
+
+fn dashboard_html(bundle: &ForecastBundle) -> String {
+    let now_hour = Utc::now().hour() as u8;
+    let current = find_current_point(&bundle.points, now_hour)
+        .or_else(|| bundle.points.first())
+        .cloned();
+
+    let mut hourly_rows = String::new();
+    for point in bundle.points.iter().take(8) {
+        let _ = write!(
+            hourly_rows,
+            "<tr><td>{:02}:00</td><td>{:.1}°F</td><td>{:.1} mph</td><td>{}</td><td>{:.1}</td></tr>",
+            point.hour,
+            point.temp_f,
+            point.wind_mph,
+            point
+                .aqi
+                .map(|v| format!("{v:.0}"))
+                .unwrap_or_else(|| "-".to_string()),
+            point.uv_index.unwrap_or(0.0)
+        );
+    }
+
+    let (temp_now, feels_now, wind_now, aqi_now) = match current {
+        Some(p) => (
+            format!("{:.1}°F", p.temp_f),
+            format!("{:.1}°F", p.feels_like_f),
+            format!("{:.1} mph", p.wind_mph),
+            p.aqi
+                .map(|v| format!("{v:.0}"))
+                .unwrap_or_else(|| "-".to_string()),
+        ),
+        None => (
+            "-".to_string(),
+            "-".to_string(),
+            "-".to_string(),
+            "-".to_string(),
+        ),
+    };
+
+    let template = r#"<!doctype html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -136,17 +243,32 @@ fn dashboard_html() -> String {
     <main class="container">
         <section class="hero">
             <h1>The Farm Monitor: How's the Weather? <span class="badge">Rust Phase C</span></h1>
-            <p>UI parity shell in progress. This page mirrors section structure while data-backed charts are phased in.</p>
+            <p>Live model-backed preview using normalized forecast data (__SOURCE__).</p>
         </section>
 
         <section class="grid">
             <article class="card span-8">
                 <h2>Temperature Trend</h2>
-                <p>Chart placeholder for actual vs forecast temperature with threshold and historical context.</p>
+                <p>Preview rows (hour, temp, wind, AQI, UV):</p>
+                <table style="width:100%;border-collapse:collapse;margin-top:0.5rem;font-size:0.92rem;">
+                    <thead>
+                        <tr style="text-align:left;color:#9da7b3;">
+                            <th style="padding:0.25rem 0;">Hour</th>
+                            <th>Temp</th>
+                            <th>Wind</th>
+                            <th>AQI</th>
+                            <th>UV</th>
+                        </tr>
+                    </thead>
+                    <tbody>__HOURLY_ROWS__</tbody>
+                </table>
             </article>
             <article class="card span-4">
                 <h2>Current Conditions</h2>
-                <p>Live now card placeholder for temperature, feels-like, wind, and quick status badges.</p>
+                <p><strong>Now Temp:</strong> __TEMP_NOW__</p>
+                <p><strong>Feels Like:</strong> __FEELS_NOW__</p>
+                <p><strong>Wind:</strong> __WIND_NOW__</p>
+                <p><strong>AQI:</strong> __AQI_NOW__</p>
             </article>
 
             <article class="card span-6">
@@ -166,26 +288,88 @@ fn dashboard_html() -> String {
 
             <article class="card span-12">
                 <h2>Data Sources</h2>
-                <p>Visual Crossing, Open-Meteo, and AQI integrations will be wired in during subsequent Phase C milestones.</p>
+                <p>Current source: <code>__SOURCE__</code> | Generated at: __GENERATED_AT__</p>
             </article>
         </section>
     </main>
 </body>
 </html>
 "#;
-    html.to_string()
+
+    template
+        .replace("__SOURCE__", &bundle.source)
+        .replace("__GENERATED_AT__", &bundle.generated_at.to_rfc3339())
+        .replace("__HOURLY_ROWS__", &hourly_rows)
+        .replace("__TEMP_NOW__", &temp_now)
+        .replace("__FEELS_NOW__", &feels_now)
+        .replace("__WIND_NOW__", &wind_now)
+        .replace("__AQI_NOW__", &aqi_now)
+}
+
+fn error_dashboard_html(error: &str) -> String {
+    format!(
+        "<html><body style='font-family:sans-serif;padding:1rem;'><h1>Dashboard unavailable</h1><p>{error}</p></body></html>"
+    )
+}
+
+fn find_current_point(points: &[ForecastPoint], hour: u8) -> Option<&ForecastPoint> {
+    points.iter().find(|p| p.hour == hour)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::dashboard_html;
+    use super::{dashboard_html, find_current_point};
+    use chrono::Utc;
+    use farm_monitor_data::{ForecastBundle, ForecastPoint};
+
+    fn sample_bundle() -> ForecastBundle {
+        ForecastBundle {
+            source: "test-source".to_string(),
+            generated_at: Utc::now(),
+            points: vec![
+                ForecastPoint {
+                    hour: 9,
+                    temp_f: 55.1,
+                    feels_like_f: 54.8,
+                    wind_mph: 6.0,
+                    aqi: Some(42.0),
+                    uv_index: Some(2.1),
+                    cloud_cover_pct: Some(25.0),
+                },
+                ForecastPoint {
+                    hour: 10,
+                    temp_f: 57.3,
+                    feels_like_f: 57.1,
+                    wind_mph: 6.8,
+                    aqi: Some(44.0),
+                    uv_index: Some(3.4),
+                    cloud_cover_pct: Some(22.0),
+                },
+            ],
+        }
+    }
 
     #[test]
     fn dashboard_contains_core_phase_c_sections() {
-        let html = dashboard_html();
+        let html = dashboard_html(&sample_bundle());
         assert!(html.contains("Temperature Trend"));
         assert!(html.contains("Wind Outlook"));
         assert!(html.contains("Air Quality"));
         assert!(html.contains("Sunrise / Sunset / Brightness"));
+    }
+
+    #[test]
+    fn dashboard_renders_data_rows_from_bundle() {
+        let html = dashboard_html(&sample_bundle());
+        assert!(html.contains("test-source"));
+        assert!(html.contains("09:00"));
+        assert!(html.contains("55.1°F"));
+    }
+
+    #[test]
+    fn find_current_point_returns_match_when_hour_exists() {
+        let bundle = sample_bundle();
+        let point = find_current_point(&bundle.points, 10).expect("point exists");
+        assert_eq!(point.temp_f, 57.3);
     }
 }


### PR DESCRIPTION
## Summary
Implements Rust migration **Phase C part 2** by wiring the dashboard to normalized forecast data and cache-backed loading in the API layer.

## What changed
- Add data-loading flow for `/dashboard`:
  - load `ForecastBundle` from file cache for current day when available
  - otherwise generate provider response, normalize it, write cache, and run retention cleanup
- Replace static placeholder rendering with data-backed HTML:
  - current conditions card (temp, feels-like, wind, AQI)
  - hourly preview table rows (hour, temp, wind, AQI, UV)
  - source + generated timestamp in Data Sources section
- Add helper functions:
  - current-hour point selection
  - dashboard error fallback HTML when data load fails
- Expand tests for:
  - core section presence
  - bundle-backed data rendering
  - current-point lookup

## Dependency updates
- `farm-monitor-api` now depends on:
  - `farm-monitor-data`
  - `anyhow`
  - `chrono`
- `Cargo.lock` updated accordingly

## Validation
Executed in `rust/`:
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`

All checks passed.

## Notes
- This keeps the existing Phase C visual shell while replacing static placeholder values with normalized/cache-backed data wiring.
- Follow-on phases can swap the mock provider generation path for live provider integrations without changing the dashboard route contract.

Refs #94