### PR TITLE
Phase C follow-up: shell/layout parity with main (#103)

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,6 +127,33 @@ def wind_degree_to_cardinal(degrees: float | None) -> str:
     return dirs[idx]
 
 
+def _finite_float(value: Any) -> float | None:
+    """Return a finite float value or None for missing/non-finite inputs."""
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(f):
+        return None
+    return f
+
+
+def _rounded_if_finite(value: Any, digits: int) -> float | None:
+    f = _finite_float(value)
+    if f is None:
+        return None
+    return round(f, digits)
+
+
+def _int_if_finite(value: Any) -> int | None:
+    f = _finite_float(value)
+    if f is None:
+        return None
+    return int(round(f))
+
+
 def _get_vc_api_key() -> str:
     """Return Visual Crossing API key from Streamlit secrets or environment."""
     env_key = os.getenv("VISUAL_CROSSING_API_KEY")
@@ -872,7 +899,7 @@ def fetch_forecast_and_current(vc_api_key: str) -> tuple[pd.DataFrame, dict]:
                         "PrecipProb": round(precipprob, 1) if precipprob is not None else None,
                         "Humidity": round(humidity, 1) if humidity is not None else None,
                         "SnowIn": round(snow, 2) if snow is not None else None,
-                        "AQI": int(round(aqi)) if aqi is not None else None,
+                            "AQI": _int_if_finite(aqi),
                         "PM2_5": pm25,
                         "PM10": pm10,
                         "O3": o3,
@@ -880,7 +907,7 @@ def fetch_forecast_and_current(vc_api_key: str) -> tuple[pd.DataFrame, dict]:
                         "SO2": so2,
                         "CO": co,
                         "MainUS": mainus,
-                        "UVIndex": int(round(uvindex)) if uvindex is not None else None,
+                            "UVIndex": _int_if_finite(uvindex),
                         "CloudCover": round(cloudcover, 1) if cloudcover is not None else None,
                         "SolarRadiation": round(solarradiation, 1)
                         if solarradiation is not None
@@ -961,17 +988,17 @@ def fetch_forecast_and_current(vc_api_key: str) -> tuple[pd.DataFrame, dict]:
         live_solarradiation = forecast_df.iloc[-1]["SolarRadiation"]
 
     live_temp = {
-        "Actual": round(live_actual, 1) if live_actual is not None else None,
-        "FeelsLike": round(live_feelslike, 1) if live_feelslike is not None else None,
-        "WindSpeed": round(live_windspeed, 1) if live_windspeed is not None else None,
-        "WindGust": round(live_windgust, 1) if live_windgust is not None else None,
-        "WindDeg": round(live_winddeg, 1) if live_winddeg is not None else None,
-        "WindDir": wind_degree_to_cardinal(live_winddeg) if live_winddeg is not None else "Unknown",
-        "PrecipIn": round(live_precip, 2) if live_precip is not None else None,
-        "PrecipProb": round(live_precipprob, 1) if live_precipprob is not None else None,
-        "Humidity": round(live_humidity, 1) if live_humidity is not None else None,
-        "SnowIn": round(live_snow, 2) if live_snow is not None else None,
-        "AQI": int(round(live_aqi)) if live_aqi is not None else None,
+        "Actual": _rounded_if_finite(live_actual, 1),
+        "FeelsLike": _rounded_if_finite(live_feelslike, 1),
+        "WindSpeed": _rounded_if_finite(live_windspeed, 1),
+        "WindGust": _rounded_if_finite(live_windgust, 1),
+        "WindDeg": _rounded_if_finite(live_winddeg, 1),
+        "WindDir": wind_degree_to_cardinal(live_winddeg) if _finite_float(live_winddeg) is not None else "Unknown",
+        "PrecipIn": _rounded_if_finite(live_precip, 2),
+        "PrecipProb": _rounded_if_finite(live_precipprob, 1),
+        "Humidity": _rounded_if_finite(live_humidity, 1),
+        "SnowIn": _rounded_if_finite(live_snow, 2),
+        "AQI": _int_if_finite(live_aqi),
         "PM2_5": live_pm25,
         "PM10": live_pm10,
         "O3": live_o3,
@@ -979,23 +1006,21 @@ def fetch_forecast_and_current(vc_api_key: str) -> tuple[pd.DataFrame, dict]:
         "SO2": live_so2,
         "CO": live_co,
         "MainUS": live_mainus,
-        "UVIndex": int(round(live_uvindex)) if live_uvindex is not None else None,
-        "CloudCover": round(live_cloudcover, 1) if live_cloudcover is not None else None,
-        "SolarRadiation": round(live_solarradiation, 1)
-        if live_solarradiation is not None
-        else None,
+        "UVIndex": _int_if_finite(live_uvindex),
+        "CloudCover": _rounded_if_finite(live_cloudcover, 1),
+        "SolarRadiation": _rounded_if_finite(live_solarradiation, 1),
         "Sunrise": today_sunrise,
         "Sunset": today_sunset,
-        "UVIndexMax": int(round(today_uvindex_max)) if today_uvindex_max is not None else None,
+        "UVIndexMax": _int_if_finite(today_uvindex_max),
     }
 
     return forecast_df, live_temp
 
 
 def aqi_interpretation(aqi: float | int | None) -> str:
-    if aqi is None:
+    value = _finite_float(aqi)
+    if value is None:
         return "Unavailable"
-    value = float(aqi)
     if value <= 50:
         return "Good"
     if value <= 100:
@@ -1011,9 +1036,9 @@ def aqi_interpretation(aqi: float | int | None) -> str:
 
 def uv_interpretation(uv: float | int | None) -> str:
     """Return a plain-English UV exposure category."""
-    if uv is None:
+    v = _finite_float(uv)
+    if v is None:
         return "Unavailable"
-    v = float(uv)
     if v <= 2:
         return "Low"
     if v <= 5:
@@ -2590,12 +2615,13 @@ def run_app() -> None:
     air_actual = air_df[air_df["Hour"] <= current_hour].copy()
     air_actual_values = air_actual["AQI"].dropna()
 
-    if live_aqi is None and not air_actual_values.empty:
+    live_aqi_f = _finite_float(live_aqi)
+    if live_aqi_f is None and not air_actual_values.empty:
         current_aqi = float(air_actual.sort_values("Hour").iloc[-1]["AQI"])
-    elif live_aqi is None:
+    elif live_aqi_f is None:
         current_aqi = None
     else:
-        current_aqi = float(live_aqi)
+        current_aqi = live_aqi_f
 
     if air_actual_values.empty:
         highest_aqi = None
@@ -2749,8 +2775,9 @@ def run_app() -> None:
             )
     if peak_uv is None:
         day_max = live_temp.get("UVIndexMax")
-        if day_max is not None:
-            peak_uv = int(day_max)
+        day_max_f = _finite_float(day_max)
+        if day_max_f is not None:
+            peak_uv = int(day_max_f)
 
     b1, b2, b3, b4 = st.columns(4)
     b1.metric(

--- a/docs/verification/rust-102a-layout-parity-notes.md
+++ b/docs/verification/rust-102a-layout-parity-notes.md
@@ -1,0 +1,24 @@
+# #102A Layout Parity Notes
+
+Date: 2026-05-25
+Issue: #103
+Parent: #102
+
+## Goal
+Align Rust dashboard shell/layout with the current main dashboard flow and spacing expectations.
+
+## Before
+- Heavy dark-theme card grid across nearly all sections.
+- Uniform card treatment reduced hierarchy between top-level and lower sections.
+- Dashboard flow looked more like a custom admin panel than Streamlit-style report sections.
+
+## After
+- Light shell with neutral background and simplified section cards.
+- Top row split emphasizes Temperature Trend + Current Conditions similar to main dashboard rhythm.
+- Wind/AQI remain paired in a middle row; lower sections stack in report-style flow.
+- Added section dividers to mimic main dashboard section progression.
+- Responsive behavior keeps mobile stacking rules for all spans.
+
+## Notes
+- This issue focuses shell/layout parity only.
+- Section-level formatting polish and chart treatment parity are tracked in #104 and #105.

--- a/docs/verification/rust-main-dashboard-parity-constraints.md
+++ b/docs/verification/rust-main-dashboard-parity-constraints.md
@@ -1,100 +1,180 @@
-# Rust vs Main Dashboard Parity Constraints
+# Rust vs Main Dashboard Comprehensive Constraints and Requirements
 
-Date: 2026-05-25
+Date: 2026-05-27
 Parent issue: #102
-Purpose: tighten parity definition against the Streamlit main dashboard behavior in app.py.
+Purpose: define a canonical, traceable constraints and requirements baseline for Rust parity work, using docs, wiki, chat-history signals, issues, and PR evidence.
 
-## Baseline Definition
-The source of truth for parity is the user-visible behavior and information architecture in app.py.
-Parity is not satisfied by section name matching alone; it requires control flow, metric semantics, and chart/legend meaning parity.
+## 1) Source Plan
 
-## Constraint Levels
-- P0 (must match before #102 close): user-facing controls, section ordering, key metric semantics, status banners, and chart intent (observed vs forecast + legends).
-- P1 (strongly expected in #102B/#102C): formatting/typography/table structure and data-source transparency wording quality.
-- P2 (acceptable deferred only with explicit approval): interaction polish and non-critical visual tuning.
+### 1.1 Authoritative functional sources
+- `app.py` (user-visible behavior source of truth)
+- `docs/feature-requirements.md` (feature contract)
+- `docs/verification/rust-main-dashboard-parity-constraints.md` (this canonical parity baseline)
 
-## Explicit Constraints (from main app)
+### 1.2 Supporting markdown sources in docs
+- `docs/Model_documentation_process.md`
+- `docs/ProcessPreferencesNotes.md`
+- `docs/feature-requirements.md`
+- `docs/ops.md`
+- `docs/rust-phase-c-ui-parity-checklist.md`
+- `docs/scientific-paper-draft.md`
+- `docs/uor/adr-0001-uor-backend-integration-mode.md`
+- `docs/uor/issue-9-followup-issues.md`
+- `docs/uor/issue-9-uor-evaluation.md`
+- `docs/c4/README.md`
+- `docs/c4/c1-system-context.md`
+- `docs/c4/c2-container-diagram.md`
+- `docs/c4/c3-component-diagram.md`
+- `docs/c4/c4-code-level-diagram.md`
+- `docs/c4/c4-ui-feature-map.md`
+- `docs/c4/wiki-page-2-c4-descriptions-draft.md`
+- `docs/c4/.maintenance/latest-c4-update-report.md`
+- `docs/c4/.maintenance/wiki-c4-embed-snippets.md`
+- `docs/verification/rust-102a-layout-parity-notes.md`
+- `docs/verification/rust-parity-pass-fail-matrix-template.md`
 
-### 1) Top-level controls and runtime context (P0)
-- Include controls equivalent to:
-  - Monitoring mode selector (winter/summer threshold mode).
-  - Temperature type toggle (Feels Like vs Actual).
-  - Kitty wind cutoff control.
-- Show runtime/profile context line (profile, data mode, live API on/off).
-- DEV-only guardrail information can be simplified in Rust, but omission must be documented as intentional deviation.
+### 1.3 Chat history sources (supplemental signals)
+- `docs/chat_history/chat01.json`
+- `docs/chat_history/chat02.json`
+- `docs/chat_history/chat03.json`
+- `docs/chat_history/chat04.json`
+- `docs/chat_history/chat05.json`
 
-### 2) Core section order and hierarchy (P0)
-Required section progression:
-1. Kitty comfort banner (above temperature area)
+Use rule: chat history can inform recurring pain points and acceptance expectations, but does not override explicit contracts in `docs/feature-requirements.md` or `app.py`.
+
+### 1.4 Wiki sources
+- `the-farm-monitor.wiki/Home.md`
+- `the-farm-monitor.wiki/Model-Purpose-and-Problem.md`
+- `the-farm-monitor.wiki/Model-Architecture-and-Behavior.md`
+- `the-farm-monitor.wiki/Model-Validation-and-Evidence.md`
+- `the-farm-monitor.wiki/Model-Limitations-and-Risks.md`
+- `the-farm-monitor.wiki/Model-Change-Log-and-Traceability.md`
+- `the-farm-monitor.wiki/Model-Documentation-Process.md`
+
+### 1.5 Traceability sources from GitHub
+
+Issues (primary parity chain):
+- #94, #102, #103, #104, #105, #106, #107
+
+PRs (primary parity chain):
+- #99, #100, #101, #108
+
+Related historical behavior evidence:
+- Issues #1, #2, #3, #4, #7, #17, #22, #25, #30, #32, #34, #41, #43, #44, #45, #47, #50, #52, #55, #57, #58, #67, #69, #70, #83, #87, #88
+- PRs #31, #35, #42, #46, #48, #49, #51, #53, #54, #56, #59, #60, #61, #65, #71, #72, #84, #85, #87, #88
+
+## 2) Constraint Levels
+- P0 (must match before #102 close): controls, section ordering, metric semantics, banner decision logic, chart intent and legend semantics.
+- P1 (strongly expected in #102B/#102C): formatting/typography/table conventions, transparency panel quality, fallback messaging nuance.
+- P2 (allowed deferred with explicit approval): visual polish and non-critical interactions.
+
+## 3) Comprehensive Constraints and Requirements
+
+### 3.1 Runtime, controls, and profile context (P0)
+REQ-001: include controls equivalent to monitoring mode, temperature type (Feels Like vs Actual), and kitty wind cutoff.
+REQ-002: show runtime/profile context (profile, data mode, live API on/off) or documented equivalent.
+REQ-003: invalid runtime combinations must fail loud, not silently degrade.
+
+### 3.2 Core section order and hierarchy (P0)
+REQ-010: section order must match main behavior flow:
+1. Kitty comfort banner
 2. Temperature metrics + trend + seasonal status + temperature chart
 3. Wind banner + wind metrics + wind chart
-4. Precipitation metrics + precipitation chart
-5. Air Quality metrics + AQI chart + pollutant breakdown table
-6. Sunrise/Sunset/Brightness metrics + brightness chart + UV/cloud legend
-7. Data sources transparency panel
+4. Precipitation metrics + chart
+5. Air Quality metrics + chart + pollutant table
+6. Sunrise/Sunset/Brightness metrics + chart + legend
+7. Data-source transparency panel
 
-### 3) Temperature behavior parity (P0)
-- Respect Feels Like vs Actual operand switch for displayed Now/High/Low and chart series.
-- Preserve 1-hour delta behavior and "since HH:00" semantics.
-- Preserve seasonal status banner decision logic (warming/cooling focus outcomes).
-- Preserve historical-band intent for temperature chart where available.
+### 3.3 Temperature and seasonal behavior (P0)
+REQ-020: Feels Like vs Actual switch drives now/high/low and chart series.
+REQ-021: 1-hour delta uses "since HH:00" semantics.
+REQ-022: winter/summer seasonal status logic must preserve success/info/warning branches.
+REQ-023: historical-band intent preserved when data is available.
 
-### 4) Kitty comfort behavior parity (P0)
-- Maintain combined pass/fail logic across:
-  - temperature comfort range,
-  - wind threshold,
-  - active rain/snow detection.
-- Banner must clearly show overall result and per-condition explanation.
+### 3.4 Kitty comfort behavior (P0)
+REQ-030: comfort combines temperature range, wind threshold, and active rain/snow status.
+REQ-031: temperature comfort semantics: $32 < temp \le 85$.
+REQ-032: wind comfort uses max(speed, gust) only when wind data exists.
+REQ-033: banner must present overall outcome plus per-condition explanation.
 
-### 5) Wind behavior parity (P0)
-- Keep explicit wind banner for fastest forecasted wind and cutoff warning behavior.
-- Keep metrics: speed now (with delta), direction, fastest wind, strongest gust.
-- Preserve chart semantics:
-  - observed vs forecast split,
-  - gust overlay treatment,
-  - historical band/mean intent where available.
+### 3.5 Wind behavior and visuals (P0)
+REQ-040: wind banner includes fastest wind and cutoff warning behavior.
+REQ-041: wind metrics include speed now (with delta), direction, fastest wind, strongest gust.
+REQ-042: wind chart semantics preserve observed vs forecast split, gust overlay, and historical-band intent.
 
-### 6) Precipitation behavior parity (P0)
-- Keep rain/snow recently boolean based on actual observed hours, not only current hour.
-- Keep total accumulation so far and now-probability/humidity metrics.
-- Keep hourly precipitation chart intent and explanatory caption.
+### 3.6 Precipitation behavior and visuals (P0)
+REQ-050: rain/snow recently is based on observed actual hours, not current hour only.
+REQ-051: include total accumulation so far, precip probability now, and humidity now.
+REQ-052: hourly precipitation chart intent and caption semantics preserved.
 
-### 7) Air quality behavior parity (P0)
-- Keep current/high/low AQI and category interpretation.
-- Keep AQI chart observed/forecast semantics and explanatory caption.
-- Pollutant breakdown should be table-like and represent missing values as "Not reported by source" equivalent semantics.
+### 3.7 Air quality behavior and visuals (P0)
+REQ-060: include current/high/low AQI and AQI interpretation category.
+REQ-061: AQI chart preserves observed vs forecast semantics.
+REQ-062: pollutant breakdown representation must support missing values using "Not reported by source" equivalent semantics.
 
-### 8) Brightness behavior parity (P0)
-- Keep sunrise/sunset/daylight metrics with yesterday deltas.
-- Keep peak UV metric and interpretation.
-- Keep dual-axis chart intent: UV (left) + cloud cover (right), with explicit legend semantics.
+### 3.8 Brightness behavior and visuals (P0)
+REQ-070: include sunrise/sunset/daylight metrics and yesterday deltas.
+REQ-071: include peak UV metric with interpretation.
+REQ-072: preserve dual-axis intent (UV left axis, cloud cover right axis) and explicit legend semantics.
 
-### 9) Data source transparency parity (P1)
-- Keep an expandable/discrete panel explaining provider roles and caveats.
-- Preserve refresh cadence transparency and blended-model caveat messaging.
+### 3.9 Data transparency and fallback messaging (P1)
+REQ-080: data-source panel should explain provider roles and blended-model caveats.
+REQ-081: include refresh cadence expectations where practical.
+REQ-082: fallback messaging should distinguish outage vs guardrail budget block vs cooldown.
+REQ-083: if simplified in Rust, differences must be documented as approved deviations.
 
-### 10) Fallback messaging parity (P1)
-- Differentiate generic outage vs guardrail block vs cooldown states in user messaging.
-- If simplified in Rust, document exact difference and rationale.
+### 3.10 Quality and governance gates
+REQ-090: Rust quality gates required for parity PRs:
+- `cargo fmt --all`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features`
 
-## Current Rust Gap Summary (as of #103 PR #108)
-- Achieved: section shell/layout flow improvements and lighter visual shell.
-- Missing/partial:
-  - top-level interactive controls parity,
-  - kitty comfort banner + seasonal status banner,
-  - chart-level parity (temperature/wind/precip/AQI/brightness),
-  - data-source transparency depth,
-  - fallback/guardrail UX messaging parity.
+REQ-091: behavior changes must update documentation and traceability artifacts in the same PR or explicitly declare no doc impact.
 
-## Mapping To Existing Child Issues
-- #103: shell/layout parity (in progress via PR #108).
-- #104: section formatting parity should explicitly include heading/metric/table conventions and section-level captions.
-- #105: chart-like visual treatment parity should explicitly include observed/forecast semantics, legends/axes, and callouts.
-- #106: verification artifacts should be upgraded to include pass/fail per constraint above.
-- #107: final closeout should include approved-deviation list with rationale for any unmet P0/P1 items.
+## 4) Overlap and Conflict Notes
 
-## Suggested Acceptance Gate Update
-Before closing #102, require a pass/fail matrix for each numbered constraint above, with one of:
+### 4.1 Overlap highlights
+- Strong overlap: `docs/feature-requirements.md` + `app.py` + parity issues/PRs (#94/#102-#108) for dashboard behavior.
+- Strong overlap: C4 docs and wiki architecture pages for system boundaries and responsibility split.
+- Strong overlap: ops/process docs and guardrail-related issues/PRs for runtime safety constraints.
+
+### 4.2 Current ambiguities to resolve
+- Brightness/UV behavior is strongly present in `app.py` and issue/PR history (#2, #88), but is under-specified in `docs/feature-requirements.md`.
+- P0 vs P1 boundary for data-source transparency wording quality requires explicit acceptance wording in #102 closure.
+- "Recently" for rain/snow should be kept as observed-hours based; if a strict time window is introduced later, it must be versioned in requirements.
+
+## 5) Issue and PR Traceability Map
+
+### 5.1 Parity decomposition map
+| Scope | Issue | PR Evidence | Status |
+|---|---|---|---|
+| Phase C umbrella | #94 | #99, #100, #101 | Closed |
+| Follow-up parity umbrella | #102 | #108 (active chain start) | Open |
+| Shell/layout parity | #103 | #108 | In progress |
+| Section formatting parity | #104 | TBD | Open |
+| Chart-like treatment parity | #105 | TBD | Open |
+| Artifact refresh | #106 | TBD | Open |
+| Final signoff and closure | #107 | TBD | Open |
+
+### 5.2 Historical feature lineage (selected)
+| Feature area | Foundational issue(s) | Implementing PR(s) |
+|---|---|---|
+| Real vs Feels Like | #1 | legacy chain prior to current parity cycle |
+| Sunrise/Sunset/Brightness | #2 | #88 |
+| Kitty comfort thresholds | #3, #67 | #61, #87 |
+| Precipitation/humidity section | #4, #41, #83 | #42, #84, #85 |
+| Wind section and semantics | #25, #32 | #46 and related chain |
+| AQI and pollutant table | #7 | #65 |
+| Guardrails and fallback resilience | #22, #30, #34, #44, #45, #50, #52, #55, #57, #58, #66, #70 | #31, #35, #49, #51, #53, #54, #56, #59, #60, #71, #72, #78 |
+
+## 6) Acceptance Gate for #102 Closeout
+Before closing #102, every requirement block in Section 3 must be marked in `docs/verification/rust-parity-pass-fail-matrix-template.md` as one of:
 - PASS
 - PASS with approved deviation
-- FAIL (must be remediated)
+- FAIL
+
+Merge-blocking rule: any P0 item marked FAIL blocks parity closeout until remediated or explicitly approved as deviation with linked issue and rationale.
+
+## 7) Current Gap Snapshot (as of PR #108)
+- Completed: shell/layout pass and parity framing artifacts.
+- Missing/partial: control parity, kitty + seasonal banners, chart semantic parity, deeper transparency panel parity, and fallback messaging nuance parity.

--- a/docs/verification/rust-main-dashboard-parity-constraints.md
+++ b/docs/verification/rust-main-dashboard-parity-constraints.md
@@ -1,0 +1,100 @@
+# Rust vs Main Dashboard Parity Constraints
+
+Date: 2026-05-25
+Parent issue: #102
+Purpose: tighten parity definition against the Streamlit main dashboard behavior in app.py.
+
+## Baseline Definition
+The source of truth for parity is the user-visible behavior and information architecture in app.py.
+Parity is not satisfied by section name matching alone; it requires control flow, metric semantics, and chart/legend meaning parity.
+
+## Constraint Levels
+- P0 (must match before #102 close): user-facing controls, section ordering, key metric semantics, status banners, and chart intent (observed vs forecast + legends).
+- P1 (strongly expected in #102B/#102C): formatting/typography/table structure and data-source transparency wording quality.
+- P2 (acceptable deferred only with explicit approval): interaction polish and non-critical visual tuning.
+
+## Explicit Constraints (from main app)
+
+### 1) Top-level controls and runtime context (P0)
+- Include controls equivalent to:
+  - Monitoring mode selector (winter/summer threshold mode).
+  - Temperature type toggle (Feels Like vs Actual).
+  - Kitty wind cutoff control.
+- Show runtime/profile context line (profile, data mode, live API on/off).
+- DEV-only guardrail information can be simplified in Rust, but omission must be documented as intentional deviation.
+
+### 2) Core section order and hierarchy (P0)
+Required section progression:
+1. Kitty comfort banner (above temperature area)
+2. Temperature metrics + trend + seasonal status + temperature chart
+3. Wind banner + wind metrics + wind chart
+4. Precipitation metrics + precipitation chart
+5. Air Quality metrics + AQI chart + pollutant breakdown table
+6. Sunrise/Sunset/Brightness metrics + brightness chart + UV/cloud legend
+7. Data sources transparency panel
+
+### 3) Temperature behavior parity (P0)
+- Respect Feels Like vs Actual operand switch for displayed Now/High/Low and chart series.
+- Preserve 1-hour delta behavior and "since HH:00" semantics.
+- Preserve seasonal status banner decision logic (warming/cooling focus outcomes).
+- Preserve historical-band intent for temperature chart where available.
+
+### 4) Kitty comfort behavior parity (P0)
+- Maintain combined pass/fail logic across:
+  - temperature comfort range,
+  - wind threshold,
+  - active rain/snow detection.
+- Banner must clearly show overall result and per-condition explanation.
+
+### 5) Wind behavior parity (P0)
+- Keep explicit wind banner for fastest forecasted wind and cutoff warning behavior.
+- Keep metrics: speed now (with delta), direction, fastest wind, strongest gust.
+- Preserve chart semantics:
+  - observed vs forecast split,
+  - gust overlay treatment,
+  - historical band/mean intent where available.
+
+### 6) Precipitation behavior parity (P0)
+- Keep rain/snow recently boolean based on actual observed hours, not only current hour.
+- Keep total accumulation so far and now-probability/humidity metrics.
+- Keep hourly precipitation chart intent and explanatory caption.
+
+### 7) Air quality behavior parity (P0)
+- Keep current/high/low AQI and category interpretation.
+- Keep AQI chart observed/forecast semantics and explanatory caption.
+- Pollutant breakdown should be table-like and represent missing values as "Not reported by source" equivalent semantics.
+
+### 8) Brightness behavior parity (P0)
+- Keep sunrise/sunset/daylight metrics with yesterday deltas.
+- Keep peak UV metric and interpretation.
+- Keep dual-axis chart intent: UV (left) + cloud cover (right), with explicit legend semantics.
+
+### 9) Data source transparency parity (P1)
+- Keep an expandable/discrete panel explaining provider roles and caveats.
+- Preserve refresh cadence transparency and blended-model caveat messaging.
+
+### 10) Fallback messaging parity (P1)
+- Differentiate generic outage vs guardrail block vs cooldown states in user messaging.
+- If simplified in Rust, document exact difference and rationale.
+
+## Current Rust Gap Summary (as of #103 PR #108)
+- Achieved: section shell/layout flow improvements and lighter visual shell.
+- Missing/partial:
+  - top-level interactive controls parity,
+  - kitty comfort banner + seasonal status banner,
+  - chart-level parity (temperature/wind/precip/AQI/brightness),
+  - data-source transparency depth,
+  - fallback/guardrail UX messaging parity.
+
+## Mapping To Existing Child Issues
+- #103: shell/layout parity (in progress via PR #108).
+- #104: section formatting parity should explicitly include heading/metric/table conventions and section-level captions.
+- #105: chart-like visual treatment parity should explicitly include observed/forecast semantics, legends/axes, and callouts.
+- #106: verification artifacts should be upgraded to include pass/fail per constraint above.
+- #107: final closeout should include approved-deviation list with rationale for any unmet P0/P1 items.
+
+## Suggested Acceptance Gate Update
+Before closing #102, require a pass/fail matrix for each numbered constraint above, with one of:
+- PASS
+- PASS with approved deviation
+- FAIL (must be remediated)

--- a/docs/verification/rust-parity-pass-fail-matrix-template.md
+++ b/docs/verification/rust-parity-pass-fail-matrix-template.md
@@ -1,0 +1,56 @@
+# Rust Main Dashboard Parity Pass-Fail Matrix Template
+
+Date: YYYY-MM-DD
+Parent issue: #102
+Verification issue: #106
+Reviewer: <name>
+Reference constraints: docs/verification/rust-main-dashboard-parity-constraints.md
+
+Legend:
+- PASS
+- PASS with approved deviation
+- FAIL
+
+## Summary
+- Total constraints reviewed: 10
+- PASS: 0
+- PASS with approved deviation: 0
+- FAIL: 0
+
+## Constraint Matrix
+
+| # | Constraint | Status | Evidence (file/PR/artifact) | Notes / Deviation Rationale |
+|---|---|---|---|---|
+| 1 | Top-level controls and runtime context |  |  |  |
+| 2 | Core section order and hierarchy |  |  |  |
+| 3 | Temperature behavior parity |  |  |  |
+| 4 | Kitty comfort behavior parity |  |  |  |
+| 5 | Wind behavior parity |  |  |  |
+| 6 | Precipitation behavior parity |  |  |  |
+| 7 | Air quality behavior parity |  |  |  |
+| 8 | Brightness behavior parity |  |  |  |
+| 9 | Data source transparency parity |  |  |  |
+| 10 | Fallback messaging parity |  |  |  |
+
+## Desktop Review Notes
+- Browser / viewport:
+- Observed differences:
+- Screens/artifacts:
+
+## Mobile Review Notes
+- Device / viewport:
+- Observed differences:
+- Screens/artifacts:
+
+## Approved Deviations
+- Deviation ID:
+- Constraint #:
+- Approval source:
+- Reason:
+- Follow-up issue (if any):
+
+## Exit Criteria
+- [ ] All P0 constraints are PASS or PASS with approved deviation
+- [ ] All P1 constraints are PASS or PASS with approved deviation
+- [ ] Any FAIL has a linked issue and disposition
+- [ ] Parent #102 updated with links to this matrix and supporting artifacts

--- a/rust/crates/farm-monitor-api/src/main.rs
+++ b/rust/crates/farm-monitor-api/src/main.rs
@@ -340,40 +340,62 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
     <title>The Farm Monitor (Rust)</title>
     <style>
         :root {
-            --bg: #0e1117;
-            --panel: #161b22;
-            --text: #e6edf3;
-            --muted: #9da7b3;
-            --accent: #22d3ee;
-            --good: #9ad162;
-            --warn: #f5b800;
+            --bg: #f7f9fc;
+            --panel: #ffffff;
+            --text: #1f2937;
+            --muted: #5f6b7a;
+            --accent: #2563eb;
+            --good: #22a06b;
+            --warn: #d97706;
+            --border: #dbe3ee;
         }
         * { box-sizing: border-box; }
         body {
             margin: 0;
             font-family: \"Segoe UI\", Tahoma, Geneva, Verdana, sans-serif;
-            background: radial-gradient(circle at 20% 0%, #1d2735, var(--bg) 45%);
+            background: var(--bg);
             color: var(--text);
         }
-        .container { max-width: 1200px; margin: 0 auto; padding: 1.25rem; }
-        .hero {
-            background: linear-gradient(135deg, #142033, #101827);
-            border: 1px solid #273244;
-            border-radius: 14px;
-            padding: 1rem 1.25rem;
-            margin-bottom: 1rem;
+        .container {
+            max-width: 1120px;
+            margin: 0 auto;
+            padding: 1.25rem 1rem 2rem;
         }
-        .hero h1 { margin: 0 0 0.35rem 0; font-size: 1.45rem; }
+        .hero {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 0.95rem 1.05rem;
+            margin-bottom: 0.9rem;
+        }
+        .hero h1 { margin: 0 0 0.35rem 0; font-size: 1.3rem; }
         .hero p { margin: 0; color: var(--muted); }
-        .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 0.9rem; }
+        .layout {
+            display: grid;
+            gap: 0.9rem;
+        }
+        .layout-row {
+            display: grid;
+            grid-template-columns: repeat(12, minmax(0, 1fr));
+            gap: 0.9rem;
+        }
+        .stack {
+            display: grid;
+            gap: 0.9rem;
+        }
+        .section-divider {
+            border: 0;
+            border-top: 1px solid var(--border);
+            margin: 0.2rem 0 0.4rem;
+        }
         .card {
             background: var(--panel);
-            border: 1px solid #2a3342;
-            border-radius: 12px;
-            padding: 0.9rem;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 0.85rem 0.95rem;
             min-height: 120px;
         }
-        .card h2 { margin: 0 0 0.5rem 0; font-size: 1rem; }
+        .card h2 { margin: 0 0 0.5rem 0; font-size: 1.02rem; }
         .card p { margin: 0; color: var(--muted); line-height: 1.4; }
         .metrics {
             display: grid;
@@ -383,13 +405,13 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
             margin-bottom: 0.65rem;
         }
         .metric {
-            border: 1px solid #2f3a4c;
-            border-radius: 9px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
             padding: 0.45rem 0.55rem;
-            background: #111a27;
+            background: #fbfdff;
         }
-        .metric .k { color: #95a7be; font-size: 0.78rem; margin-bottom: 0.2rem; }
-        .metric .v { font-size: 0.92rem; font-weight: 600; color: #dbe9f6; }
+        .metric .k { color: #617287; font-size: 0.78rem; margin-bottom: 0.2rem; }
+        .metric .v { font-size: 0.92rem; font-weight: 600; color: #1f2937; }
         .mini-table {
             width: 100%;
             border-collapse: collapse;
@@ -398,19 +420,19 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
         }
         .mini-table th {
             text-align: left;
-            color: #97a8bc;
-            border-bottom: 1px solid #2b384a;
+            color: #607286;
+            border-bottom: 1px solid var(--border);
             padding: 0.3rem 0.2rem;
         }
         .mini-table td {
-            border-bottom: 1px solid #223044;
-            color: #d5e2ef;
+            border-bottom: 1px solid #edf1f7;
+            color: #374151;
             padding: 0.32rem 0.2rem;
             vertical-align: middle;
         }
         .bar {
             width: 100%;
-            background: #172131;
+            background: #e9eff6;
             border-radius: 999px;
             overflow: hidden;
             height: 0.52rem;
@@ -423,6 +445,8 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
         .span-6 { grid-column: span 6; }
         .span-8 { grid-column: span 8; }
         .span-12 { grid-column: span 12; }
+        .span-3 { grid-column: span 3; }
+        .span-9 { grid-column: span 9; }
         .legend { font-size: 0.92rem; color: var(--muted); margin-top: 0.55rem; }
         .legend .uv { color: var(--warn); font-weight: 600; }
         .legend .cloud { color: var(--accent); font-weight: 600; }
@@ -432,12 +456,12 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
             font-size: 0.75rem;
             border-radius: 999px;
             padding: 0.15rem 0.5rem;
-            color: #09101a;
+            color: #ffffff;
             background: var(--good);
             vertical-align: middle;
         }
         @media (max-width: 900px) {
-            .span-4, .span-6, .span-8, .span-12 { grid-column: span 12; }
+            .span-3, .span-4, .span-6, .span-8, .span-9, .span-12 { grid-column: span 12; }
         }
     </style>
 </head>
@@ -448,8 +472,9 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
             <p>Live model-backed preview using normalized forecast data (__SOURCE__).</p>
         </section>
 
-        <section class=\"grid\">
-            <article class=\"card span-8\">
+        <section class=\"layout\">
+            <div class=\"layout-row\">
+            <article class=\"card span-9\">
                 <h2>Temperature Trend</h2>
                 <p>Preview rows (hour, temp, wind, AQI, UV):</p>
                 <table class=\"mini-table\">
@@ -457,14 +482,18 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
                     <tbody>__HOURLY_ROWS__</tbody>
                 </table>
             </article>
-            <article class=\"card span-4\">
+            <article class=\"card span-3\">
                 <h2>Current Conditions</h2>
                 <p><strong>Now Temp:</strong> __TEMP_NOW__</p>
                 <p><strong>Feels Like:</strong> __FEELS_NOW__</p>
                 <p><strong>Wind:</strong> __WIND_NOW__</p>
                 <p><strong>AQI:</strong> __AQI_NOW__</p>
             </article>
+            </div>
 
+            <hr class=\"section-divider\" />
+
+            <div class=\"layout-row\">
             <article class=\"card span-6\">
                 <h2>Wind Outlook</h2>
                 <div class=\"metrics\">
@@ -478,7 +507,6 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
                     <tbody>__WIND_ROWS__</tbody>
                 </table>
             </article>
-
             <article class=\"card span-6\">
                 <h2>Air Quality</h2>
                 <div class=\"metrics\">
@@ -493,7 +521,11 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
                 </table>
                 <p style=\"margin-top:0.55rem;\">Pollutant Breakdown: PM2.5 __PM25__ ug/m3 | PM10 __PM10__ ug/m3 | O3 __O3__ ppb | NO2 __NO2__ ppb | CO __CO__ ppm</p>
             </article>
+            </div>
 
+            <hr class=\"section-divider\" />
+
+            <div class=\"stack\">
             <article class=\"card span-12\">
                 <h2>Precipitation</h2>
                 <div class=\"metrics\">
@@ -526,8 +558,9 @@ fn dashboard_html(bundle: &ForecastBundle) -> String {
             <article class=\"card span-12\">
                 <h2>Data Sources</h2>
                 <p>Current source: <code>__SOURCE__</code> | Generated at: __GENERATED_AT__</p>
-                <p style=\"margin-top:0.5rem;\">Open-Meteo and Visual Crossing semantics are represented in this phase by a normalized source contract; series are shown as observed and forecast for parity behavior review.</p>
+                <p style=\"margin-top:0.5rem;\">Open-Meteo and Visual Crossing semantics are represented in this phase by a normalized source contract; series are shown as observed (solid semantics) and forecast (continuation semantics) for parity behavior review.</p>
             </article>
+            </div>
         </section>
     </main>
 </body>

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -334,6 +334,10 @@ def test_aqi_interpretation_thresholds(aqi, expected):
     assert app.aqi_interpretation(aqi) == expected
 
 
+def test_aqi_interpretation_nan_is_unavailable():
+    assert app.aqi_interpretation(float("nan")) == "Unavailable"
+
+
 def test_format_dev_guardrail_sidebar_line_near_limit_shows_warning():
     item = {
         "label": "VC forecast/current",
@@ -1401,6 +1405,10 @@ def test_uv_interpretation_thresholds(uv, expected):
     assert app.uv_interpretation(uv) == expected
 
 
+def test_uv_interpretation_nan_is_unavailable():
+    assert app.uv_interpretation(float("nan")) == "Unavailable"
+
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
@@ -1506,3 +1514,45 @@ def test_fetch_forecast_and_current_maps_uv_cloud_solar_fields(monkeypatch):
     assert live_temp["Sunrise"] == "06:15:00"
     assert live_temp["Sunset"] == "20:10:00"
     assert live_temp["UVIndexMax"] == 9
+
+
+def test_fetch_forecast_and_current_handles_non_finite_aqi_uv(monkeypatch):
+    payload = {
+        "days": [
+            {
+                "sunrise": "06:15:00",
+                "sunset": "20:10:00",
+                "uvindex": float("nan"),
+                "hours": [
+                    {
+                        "datetime": "12:00:00",
+                        "temp": 72.0,
+                        "feelslike": 70.0,
+                        "windspeed": 5.0,
+                        "aqius": float("nan"),
+                        "uvindex": float("nan"),
+                        "cloudcover": 25.0,
+                    }
+                ],
+            }
+        ],
+        "currentConditions": {
+            "temp": 72.0,
+            "feelslike": 70.0,
+            "windspeed": 5.0,
+            "aqius": float("nan"),
+            "uvindex": float("nan"),
+            "cloudcover": 30.0,
+        },
+    }
+
+    def fake_get(url, params, timeout):
+        return _MockResponse(payload)
+
+    monkeypatch.setattr(app.requests, "get", fake_get)
+
+    _, live_temp = app.fetch_forecast_and_current.__wrapped__("fake-key")
+
+    assert live_temp["AQI"] is None
+    assert live_temp["UVIndex"] is None
+    assert live_temp["UVIndexMax"] is None


### PR DESCRIPTION
## Summary
- move Rust dashboard shell from dark card-grid styling to a lighter section-first layout flow
- introduce layout, layout-row, stack, and section dividers for parity with main dashboard rhythm
- adjust top-row composition to Temperature Trend + Current Conditions (9/3 split) and keep Wind/AQI paired
- add verification notes artifact for before/after parity decisions

## Validation
- cargo fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features

Closes #103
Refs #102
