### PR TITLE
Fix AQI chart KeyError when AQI data is missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -2026,7 +2026,7 @@ def build_aqi_chart(df: pd.DataFrame, current_hour: int) -> alt.LayerChart:
     hi_hour = actual.loc[actual["AQI"] == hi, "Hour"].iloc[0] if hi is not None else None
     lo_hour = actual.loc[actual["AQI"] == lo, "Hour"].iloc[0] if lo is not None else None
 
-    callouts = pd.DataFrame()
+    callouts = pd.DataFrame(columns=["Hour", "AQI", "Label"])
     if hi is not None and lo is not None:
         callouts = pd.DataFrame(
             [

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -983,6 +983,20 @@ def test_build_precip_chart_x_axis_domain_is_full_day():
     assert x_encoding.get("scale", {}).get("domain") == [0, 23]
 
 
+def test_build_aqi_chart_handles_missing_observed_values_without_keyerror():
+    df = pd.DataFrame(
+        {
+            "Hour": list(range(24)),
+            "AQI": [None] * 24,
+        }
+    )
+
+    chart = app.build_aqi_chart(df=df, current_hour=10)
+    spec = chart.to_dict()
+
+    assert "layer" in spec
+
+
 @pytest.mark.parametrize(
     "live_temp, threshold, forecast_future, mode, expected_call",
     [


### PR DESCRIPTION
## Summary\n- prevent AQI callout filtering from raising KeyError when observed AQI is missing\n- initialize empty callouts with expected columns in build_aqi_chart\n- add regression test for all-missing observed AQI values\n\n## Validation\n- pytest -q tests/test_core_logic.py -k "build_aqi_chart_handles_missing_observed_values_without_keyerror"\n