### PR TITLE
docs: refresh parity artifacts for #106

### DIFF
--- a/docs/verification/rust-desktop-mobile-artifact-refresh-2026-06-01.md
+++ b/docs/verification/rust-desktop-mobile-artifact-refresh-2026-06-01.md
@@ -1,0 +1,41 @@
+# Rust Desktop/Mobile Artifact Refresh - 2026-06-01
+
+Issue: #106
+Related: #122, #107, #102
+
+## What was refreshed
+
+1. Post-#122 parity state was re-validated for:
+- Desktop chart semantics and layer mapping.
+- Mobile stacking/readability behavior.
+
+2. Verification artifacts updated:
+- `docs/verification/rust-main-dashboard-parity-constraints.md`
+- `docs/verification/rust-parity-pass-fail-matrix-template.md`
+
+## Desktop checks
+
+1. Temperature chart now includes:
+- target threshold line.
+- historical context band + mean overlay.
+
+2. Wind chart now includes:
+- gust overlay.
+- historical context band + mean overlay.
+
+3. AQI chart now includes:
+- explicit observed->forecast split marker and label.
+
+4. Brightness chart now includes:
+- explicit right-axis line and left/right axis communication.
+
+## Mobile checks
+
+1. One-column card flow is retained under responsive breakpoints.
+2. Metrics/cards stack to a single column to preserve readability.
+3. Chart blocks preserve axis labels and legend chips without requiring horizontal section reflow.
+
+## Acceptance statement
+
+#106 acceptance criteria are satisfied with these refreshed artifacts and matrix outcomes.
+Remaining closure steps proceed in #107 and #102.

--- a/docs/verification/rust-main-dashboard-parity-constraints.md
+++ b/docs/verification/rust-main-dashboard-parity-constraints.md
@@ -1,0 +1,49 @@
+# Rust Main Dashboard Parity Constraints
+
+Last refreshed: 2026-06-01
+Baseline commit: `9be79e0` (after PR #125 merge)
+Scope chain: #122 -> #106 -> #107 -> #102
+
+## Verification intent
+
+This document captures the current parity constraints used to compare Rust `/dashboard` output against the Python main dashboard behavior.
+
+## Must-match constraints
+
+1. Section coverage parity
+- Temperature, Wind, Air Quality, Precipitation, Brightness, Data Sources are present.
+
+2. Observed/forecast semantics parity
+- Temperature, Wind, and AQI charts split observed vs forecast by current-hour boundary.
+
+3. Chart-layer semantic parity
+- Temperature includes target threshold plus historical context (band + mean).
+- Wind includes gust overlay plus historical context (band + mean).
+- AQI includes explicit observed->forecast split marker and explanatory labels.
+- Brightness dual-axis intent is explicit (UV left axis, cloud-cover right axis).
+
+4. Control-strip parity
+- Runtime mode selector, temperature basis selector, and wind cutoff input are visible and active.
+
+5. Single-column layout parity guardrail
+- Cards render in one-column flow for desktop and mobile to avoid layout drift.
+
+## Allowed/approved deviation
+
+1. Interaction model
+- Approved deviation: static SVG semantics are accepted for Phase C parity.
+- Not required for closure: Altair-style hover/inspection interactivity parity.
+
+## Evidence anchors
+
+1. Code anchors
+- `rust/crates/farm-monitor-api/src/main.rs` chart builders and template/CSS markers.
+
+2. Validation commands
+- `cargo fmt --manifest-path rust/Cargo.toml --all`
+- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --manifest-path rust/Cargo.toml -p farm-monitor-api`
+
+3. Issue/PR traceability
+- #122 closed via PR #125.
+- Static vs interactive decision recorded in #122 comment on 2026-06-01.

--- a/docs/verification/rust-parity-pass-fail-matrix-template.md
+++ b/docs/verification/rust-parity-pass-fail-matrix-template.md
@@ -1,0 +1,27 @@
+# Rust Parity Pass/Fail Matrix
+
+Last refreshed: 2026-06-01
+Artifact issue: #106
+Baseline PR: #125
+
+| Area | Check | Result | Notes |
+|---|---|---|---|
+| Page Composition | Single-column card flow across sections | PASS | Enforced in dashboard layout CSS and card grouping. |
+| Temperature | Observed/forecast split line semantics | PASS | Current-hour boundary maintained. |
+| Temperature | Target threshold overlay | PASS | `trend-target` line present. |
+| Temperature | Historical context band + mean | PASS | `trend-band temp-band`, `trend-line temp-hist`. |
+| Wind | Observed/forecast split line semantics | PASS | Current-hour boundary maintained. |
+| Wind | Gust overlay | PASS | `trend-line gust` marker present. |
+| Wind | Historical context band + mean | PASS | `trend-band wind-band`, `trend-line wind-hist`. |
+| AQI | Observed/forecast split clarity | PASS | `trend-split` marker and split caption included. |
+| AQI | Annotation depth vs baseline expectation | PASS | Added explicit line-title semantics and split callout text. |
+| Brightness | Dual-axis communication clarity | PASS | Right axis line and explicit left/right axis labels. |
+| Legend Mapping | Layer-to-legend mapping explicit | PASS | Temperature/Wind ribbons include context layers; brightness ribbon clarifies UV/cloud layers. |
+| Desktop behavior | Core sections and chart markers render | PASS | Verified by local Rust tests + rendered marker assertions. |
+| Mobile behavior | Layout remains single-column and readable | PASS | Responsive CSS (`@media` rules) keeps one-column stacking. |
+| Interactive hover parity | Altair-equivalent hover interactions | APPROVED DEVIATION | Static SVG accepted for Phase C closure (recorded on #122). |
+
+## Notes
+
+1. This matrix is intentionally concise and closure-oriented for #106/#107.
+2. If requirements change, append new rows instead of overwriting existing pass/fail history.


### PR DESCRIPTION
## Summary
- add refreshed verification artifacts under `docs/verification/`
- add updated parity constraints anchor for post-#122 baseline
- add pass/fail matrix snapshot with approved static-SVG deviation note
- add desktop/mobile refresh artifact note to support closure package

## Files
- docs/verification/rust-main-dashboard-parity-constraints.md
- docs/verification/rust-parity-pass-fail-matrix-template.md
- docs/verification/rust-desktop-mobile-artifact-refresh-2026-06-01.md

## Why
Issue #106 requires post-#122 desktop/mobile artifact refresh and side-by-side parity findings as input to #107/#102 closure.

Closes #106
