### PR TITLE
docs: add final parity signoff package for #107

### DIFF
--- a/docs/verification/rust-phase-c-final-signoff-2026-06-01.md
+++ b/docs/verification/rust-phase-c-final-signoff-2026-06-01.md
@@ -1,0 +1,36 @@
+# Rust Phase C Final Signoff - 2026-06-01
+
+Issue: #107
+Umbrella: #102
+
+## Closure checklist
+
+1. #122 chart parity deltas
+- Status: COMPLETE
+- Evidence: PR #125 (merged)
+- Notes: historical overlays, legend mapping, AQI split clarity, brightness axis clarity, static-SVG decision recorded.
+
+2. #106 desktop/mobile artifact refresh
+- Status: COMPLETE
+- Evidence: PR #126 (merged)
+- Artifacts:
+  - docs/verification/rust-main-dashboard-parity-constraints.md
+  - docs/verification/rust-parity-pass-fail-matrix-template.md
+  - docs/verification/rust-desktop-mobile-artifact-refresh-2026-06-01.md
+
+3. Acceptance criteria evaluation for #102
+- Rust dashboard layout/format parity across migrated sections: PASS
+- Desktop/mobile parity evidence linked: PASS
+- Remaining deviations explicitly documented and approved: PASS
+
+## Approved deviations
+
+1. Interactive hover parity
+- Status: APPROVED DEVIATION
+- Decision: static SVG parity accepted for Phase C closure.
+- Traceability: issue #122 decision comment (2026-06-01).
+
+## Signoff statement
+
+Phase C parity remediation tracked under #102 is complete and evidence-backed.
+#102 can be closed with this signoff package and linked merged PRs.


### PR DESCRIPTION
## Summary
- add final Phase C parity signoff package artifact
- consolidate closure evidence from #122 and #106
- provide explicit acceptance and approved-deviation statements for #102 closure

## File
- docs/verification/rust-phase-c-final-signoff-2026-06-01.md

## Why
Issue #107 requires final closure package evidence after #122 and #106 completion.

Closes #107
