### PR TITLE
process: enforce UI review sign-off gate in PR workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,72 @@
+## Summary
+
+-
+
+## Linked Issues
+
+-
+
+## Change Type
+
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Docs/process update
+- [ ] Refactor/chore
+
+## UI Impact Classification
+
+- [ ] This PR changes user-visible UI behavior, structure, styling, layout, chart semantics, controls, or section ordering.
+- [ ] This PR is backend-only / non-UI and does not require UI review sign-off.
+
+If UI-impacting is checked, complete the required gate below before requesting merge.
+
+## Required UI Review Gate (UI-impacting PRs only)
+
+- [ ] Linked UI review gate issue (for example #128 style)
+- [ ] Review URL(s) provided
+- [ ] Run command(s) provided
+- [ ] "What changed" (user-visible only) provided
+- [ ] "What to verify" pass/fail checklist provided
+- [ ] Deferred differences listed (or explicit none)
+- [ ] Maintainer self-check evidence included
+- [ ] Final gate statement included exactly: `OK everything is good for UI review.`
+
+## UI Review Handoff
+
+### Review URL(s)
+
+-
+
+### Run Command(s)
+
+-
+
+### What Changed (User-Visible)
+
+-
+
+### What To Verify (Pass/Fail)
+
+- [ ]
+
+### Deferred Differences
+
+- None
+
+### Maintainer Self-Check Evidence
+
+-
+
+### Maintainer Final Gate Statement
+
+-
+
+## Validation
+
+- [ ] Local tests/validation run
+- [ ] Relevant CI checks pass
+
+## Notes
+
+- If no UI behavior changed, include: `No UI review gate required`.
+- Policy source issue: #129.

--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ Security note:
 - Update the wiki feature page in the same PR whenever behavior changes in weather or memo features.
 - C4/UOR materials are archived for academic reference; promote from archive only when explicitly needed for implementation decisions.
 - Update architecture narrative in wiki pages only when archived academic material is promoted back into active use.
+- For UI-impacting PRs, include a linked UI review gate issue and complete the UI Review Handoff in the PR template before merge.
+- For UI-impacting PRs, include the explicit final gate statement: `OK everything is good for UI review.`
 - If no feature behavior changed, include: `No feature-doc changes required` in the PR description.
 - If no architecture changed, include: `No C4 changes required` in the PR description.
+- If UI behavior did not change, include: `No UI review gate required` in the PR description.
 - Keep changelog and tests aligned with any feature logic changes.
 
 ## Code Formatting (Ruff)

--- a/docs/ProcessPreferencesNotes.md
+++ b/docs/ProcessPreferencesNotes.md
@@ -9,3 +9,4 @@ Why this file remains:
 
 Local-only reminder:
 - Store machine-specific secret values and ad hoc workspace notes outside of version control.
+- UI-impacting PRs must follow the UI review sign-off gate policy tracked in issue #129 and use the PR template handoff checklist.


### PR DESCRIPTION
## Summary
- add a repository PR template with a required UI review gate section
- codify UI gate expectations in local workflow docs and README policy section
- add explicit non-UI bypass wording (`No UI review gate required`)

## Files
- .github/pull_request_template.md
- README.md
- docs/ProcessPreferencesNotes.md

## Why
Implements issue #129 to prevent UI-impacting changes from skipping owner/reviewer sign-off instructions and evidence handoff.

Closes #129
